### PR TITLE
[PKG-1661] optimum 1.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "optimum" %}
-{% set version = "1.4.1" %}
+{% set version = "1.12.0" %}
 
 
 package:
@@ -8,13 +8,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f10fdc4e1a9045a375ec78ffd66aad006458d96dbd378e8a5fe0ee997ee10903
+  sha256: a74e051c4d776a900b6452a12a36e0afadbebee112a8205a30adac9216a4991b
 
 build:
   number: 0
   skip: true  # [py<37]
   script:
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -25,20 +25,24 @@ requirements:
   run:
     - python
     - coloredlogs
+    - datasets
     - sympy
     - pytorch >=1.9
-    - transformers >=4.20.1
     - huggingface_hub >=0.8.0
+    - transformers >=4.26.0
+    # transformers[sentencepiece] contains sentencepiece and protobuf, see https://github.com/huggingface/transformers/blob/v4.32.1/setup.py#L299
+    - sentencepiece >=0.1.91,!=0.1.92
+    - protobuf
     - packaging
     - numpy
 
 test:
   imports:
     - optimum
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/huggingface/optimum

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,10 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  # transformers >=4.26.0 is not available on s390x
+  skip: true  # [py<37 or s390x]
+  # Dropping ppc because of various pytorch build issues
+  skip: True  # [py>310 and (linux and ppc64le)]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -71,6 +74,3 @@ about:
 extra:
   recipe-maintainers:
     - sugatoray
-  skip-lints:
-    - missing_license_url
-    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,10 @@ requirements:
     - protobuf
     - packaging
     - numpy
+  run_contrained:
+    - onnxruntime >=1.11.0
+    - datasets >=1.2.1
+    - protobuf>=3.20.1
 
 test:
   imports:


### PR DESCRIPTION
Changelog: https://github.com/huggingface/optimum/releases
License: https://github.com/huggingface/optimum/blob/v1.12.0/LICENSE
Requirements: https://github.com/huggingface/optimum/blob/v1.12.0/setup.py

Actions:
1. Add `--no-deps --no-build-isolation` to `script`
2. Skip  `s390x` because  `transformers >=4.26.0` is not available
3. Skip `py>310 and (linux and ppc64le`) because of various `pytorch >=2.0.0` build issues, see https://github.com/AnacondaRecipes/pytorch-feedstock/blob/3e1aed5d274827e6cf999ed60622f5475417b96e/recipe/meta.yaml#L20
4. Update `run` dependencies: 
- add `datasets`
- add `sentencepiece >=0.1.91,!=0.1.92` and `protobuf` because `transformers[sentencepiece]>=4.26.0` contains `sentencepiece` and `protobuf`, see https://github.com/huggingface/transformers/blob/v4.32.1/setup.py#L299 and  https://github.com/huggingface/optimum/blob/e00afaa4c12037a01b77954c7284d477b10d6aa8/setup.py#L18C6-L18C33 
- update pinning for `transformers >=4.26.0`
5. Remove incorrect `skip-lints`